### PR TITLE
Add ResoniteHooks helper methods

### DIFF
--- a/BepInExResoniteShim.cs
+++ b/BepInExResoniteShim.cs
@@ -153,14 +153,9 @@ public static class ResoniteHooks
 {
     public static event Action<Engine>? OnEngineInit;
 
-    [HarmonyPatch]
+    [HarmonyPatch(typeof(Engine), "SetReady")]
     public class EngineInitPatch
     {
-        public static MethodBase TargetMethod()
-        {
-            return AccessTools.Method(typeof(Engine), "FinishInitialization", [typeof(LaunchOptions)]);
-        }
-
         public static void Postfix(Engine __instance)
         {
             BepInExResoniteShim.Logger.LogInfo("Engine initialization finished, firing OnEngineInit event");


### PR DESCRIPTION
It adds a `OnEngineInit` action event handler with the type of `Engine` that you can subscribe to.


Usage:
```cs
public override void Load()
{
	try
	{
		Log = base.Log;
		InitializeConfiguration();
		HarmonyInstance.PatchAll();
		ResoniteHooks.OnEngineInit += OnEngineInit;
		Log.LogInfo($"Plugin {PluginMetadata.GUID} is loaded!");
	}
	catch (Exception ex)
	{
		Log?.LogError($"Failed to load plugin: {ex}");
	}
}

private void OnEngineInit(FrooxEngine.Engine engine)
{
	try
	{
		Log?.LogInfo("Engine initialized");

		// Do your stuff here
	}
	catch (Exception ex)
	{
		Log?.LogError($"Failed to initialize engine: {ex}");
	}
}
```