### PR TITLE
Add prepatcher attribute and change ResonitePlugin

### DIFF
--- a/BepInExResoniteShim.cs
+++ b/BepInExResoniteShim.cs
@@ -2,6 +2,7 @@
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using BepInEx.NET.Common;
+using BepInEx.Preloader.Core.Patching;
 using Elements.Core;
 using FrooxEngine;
 using HarmonyLib;
@@ -13,13 +14,12 @@ namespace BepInExResoniteShim;
 
 public class ResonitePlugin : BepInPlugin
 {
-    public ResonitePlugin(string GUID, string Name, string Version, string Author, string Link) : base(GUID, Name, Version)
-    {
-        this.Author = Author;
-        this.Link = Link;
-    }
-    public string Author { get; protected set; }
-    public string Link { get; protected set; }
+    public ResonitePlugin(string GUID, string Name, string Version, string? Author = null, string? Link = null) : base(GUID, Name, Version, Author, Link) { }
+}
+
+public class ResonitePrePatcherPlugin : PatcherPluginInfoAttribute
+{
+    public ResonitePrePatcherPlugin(string GUID, string Name, string Version, string? Author = null, string? Link = null) : base(GUID, Name, Version, Author, Link) { }
 }
 
 


### PR DESCRIPTION
This depends on https://github.com/ResoniteModding/BepisLoader/pull/20 to be merged. This changes `ResonitePlugin` to be simply a renamed class and introduces `ResonitePrePatcherPlugin` which is a renamed `PatcherPluginInfoAttribute` for consistency sakes. (for backwards compatibility and consistency)

The idea is simple. `BepInExResoniteShim` should be the entry point of Resonite BepinEx modding. (it already is, including both CoreCLR and Shim in csproj is pointless unless u want to overwrite CoreCLR version for some reason)

Plugin authors should depend on `ResoniteModding.BepInExResoniteShim` in the csproj to get the references for BepisLoader (bepinex 6 fork). `BepInEx.NET.CoreCLR` should only be used for projects such as Shim itself. This has nothing to do with the Thunderstore package BepInExResoniteShim plugin, so no need to change `thunderstore.toml`. (even for prepatcher only mods)