### PR TITLE
Fix relative paths

### DIFF
--- a/BepInExResoniteShim.cs
+++ b/BepInExResoniteShim.cs
@@ -70,6 +70,7 @@ class BepInExResoniteShim : BasePlugin
         HarmonyInstance.SafePatchCategory(nameof(GraphicalClientPatch));
         HarmonyInstance.SafePatchCategory(nameof(WindowTitlePatcher));
         HarmonyInstance.SafePatchCategory(nameof(LogAlerter));
+        HarmonyInstance.SafePatchCategory(nameof(RelativePathFixer));
     }
 
     [HarmonyPatch]

--- a/RelativePathFixer.cs
+++ b/RelativePathFixer.cs
@@ -1,0 +1,82 @@
+using BepInEx;
+using FrooxEngine;
+using HarmonyLib;
+using System.Diagnostics;
+
+namespace BepInExResoniteShim;
+
+class RelativePathFixer
+{
+    [HarmonyPatchCategory(nameof(RelativePathFixer))]
+    [HarmonyPatch(typeof(LaunchOptions))]
+    class LaunchOptionsPathPatcher
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(LaunchOptions.LogsDirectory), MethodType.Getter)]
+        public static void LogsDirectory_Postfix(ref string __result)
+        {
+            if (string.IsNullOrWhiteSpace(__result))
+            {
+                __result = "Logs";
+            }
+
+            if (!string.IsNullOrWhiteSpace(__result) && !Path.IsPathRooted(__result))
+            {
+                var absolutePath = Path.Combine(Paths.GameRootPath, __result);
+                BepInExResoniteShim.Log.LogDebug($"Patched LogsDirectory from '{__result}' to '{absolutePath}'");
+                __result = absolutePath;
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(LaunchOptions.OverrideRendererIcon), MethodType.Getter)]
+        public static void OverrideRendererIcon_Postfix(ref string __result)
+        {
+            if (!string.IsNullOrWhiteSpace(__result) && !Path.IsPathRooted(__result))
+            {
+                var absolutePath = Path.Combine(Paths.GameRootPath, __result);
+                BepInExResoniteShim.Log.LogDebug($"Patched OverrideRendererIcon from '{__result}' to '{absolutePath}'");
+                __result = absolutePath;
+            }
+        }
+    }
+
+    [HarmonyPatchCategory(nameof(RelativePathFixer))]
+    [HarmonyPatch(typeof(Process), nameof(Process.Start), typeof(ProcessStartInfo))]
+    class StartRendererPatch
+    {
+        public static void Prefix(ProcessStartInfo startInfo)
+        {
+            if (startInfo == null) return;
+
+            if (startInfo.FileName != null && startInfo.FileName.Contains("Renderite.Renderer.exe"))
+            {
+                if (startInfo.WorkingDirectory == "Renderer" || string.IsNullOrEmpty(startInfo.WorkingDirectory))
+                {
+                    var originalWorkingDir = startInfo.WorkingDirectory;
+                    var correctWorkingDir = Path.GetDirectoryName(startInfo.FileName);
+                    startInfo.WorkingDirectory = correctWorkingDir;
+                    BepInExResoniteShim.Log.LogDebug($"Patched renderer WorkingDirectory from '{originalWorkingDir}' to '{correctWorkingDir}'");
+                }
+            }
+        }
+    }
+
+    [HarmonyPatchCategory(nameof(RelativePathFixer))]
+    [HarmonyPatch(typeof(File), nameof(File.WriteAllText), typeof(string), typeof(string))]
+    class CrashLogPathFixer
+    {
+        public static void Prefix(ref string path, string contents)
+        {
+            if (path != null && path.Contains("Renderite.Host.Crash"))
+            {
+                if (!Path.IsPathRooted(path))
+                {
+                    var absolutePath = Path.Combine(Paths.GameRootPath, path);
+                    BepInExResoniteShim.Log.LogDebug($"Patched crash log path from '{path}' to '{absolutePath}'");
+                    path = absolutePath;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes issue in https://github.com/ResoniteModding/BepisLoader/pull/22#issuecomment-3331097858, so we don't have to fix it in BepisLoader.

This fixes direct launching via gale or command line without being in the Resonite directory.

Changes:
  - Patches LaunchOptions property getters to convert relative paths to absolute
  - Fixes renderer process working directory when started from outside game folder
  - Ensures crash logs are written to game directory
  - All paths now correctly resolve to game root regardless of current working directory
  
  I will make a GitHub issue on Resonite's tracker soon regarding this.