### PR TITLE
fix: exclude Resonite.GameLibs runtime assets to prevent publicizer version conflicts

### DIFF
--- a/BepInExResoniteShim.csproj
+++ b/BepInExResoniteShim.csproj
@@ -33,15 +33,12 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.NET.CoreCLR" Version="6.0.0-be.*" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.ResonitePluginInfoProps" Version="3.*" />
-		<PackageReference Include="Krafs.Publicizer" Version="2.3.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		<PackageReference Include="Krafs.Publicizer" Version="2.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
 	</ItemGroup>
 
 	<!-- NuGet fallback stripped game references -->
 	<ItemGroup Condition="!Exists('$(GamePath)')">
-		<PackageReference Include="Resonite.GameLibs" Version="2025.*" PrivateAssets="all" />
+		<PackageReference Include="Resonite.GameLibs" Version="2026.*" PrivateAssets="all" ExcludeAssets="runtime" />
 	</ItemGroup>
 	
 	<!-- Local game references -->

--- a/BepInExResoniteShim.csproj
+++ b/BepInExResoniteShim.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>ResoniteModding</Authors>
     <Product>BepInEx Resonite Shim</Product>


### PR DESCRIPTION
Fixes publicizer issues for consumers of this package. Previously, mods would inherit outdated Resonite.GameLibs versions (e.g. 2025.9.2.430) as transitive dependencies of this package. This ensures mods using this package can publicize APIs from the Resonite.GameLibs version defined in their own csproj by adding a direct compile-only reference that overrides stale transitive dependencies.
